### PR TITLE
feat: add `make run` to demo-api's Makefile

### DIFF
--- a/demo-api/Makefile
+++ b/demo-api/Makefile
@@ -1,35 +1,19 @@
-AWS_PROFILE=pathfinder-prod
-AWS_REGION=eu-central-1
-LAMBDA_NAME=pathfinder-alpha
+.PHONY: all
+all:
+	@echo "Usage: make <ci|run>"
+	@echo "  - ci :: Performs tests"
+	@echo "  - run :: Starts the demo API at port 8000"
 
-build-lambda: target_lambda/deploy.zip
+.PHONY: run
+run: keypair.pem
+	PRIV_KEY=`cat keypair.pem` cargo run
 
-target_lambda/deploy.zip:
-	docker run -it --rm -v ~/.cargo/registry:/root/.cargo/registry:z -v `pwd`/:/build:z lambda_builder
-
-.PHONY: target/rust.zip
-target/rust.zip:
-	cargo build --release --target x86_64-unknown-linux-musl
-	rm -f $@
-	zip -j $@ ./target/x86_64-unknown-linux-musl/release/bootstrap
-
-local-upload: target/rust.zip
-	aws --profile=${AWS_PROFILE} lambda update-function-code \
-		--function-name ${LAMBDA_NAME} \
-		--zip-file fileb://$<  \
-		--region ${AWS_REGION}
-
-aws-upload: target_lambda/deploy.zip
-	aws --profile=${AWS_PROFILE} lambda update-function-code \
-		--function-name ${LAMBDA_NAME} \
-		--zip-file fileb://$<  \
-		--region ${AWS_REGION}
 
 
 .PHONY: ci
 ci: keypair.pem
 	cargo build
-	PRIV_KEY=`cat keypair.pem` cargo test 
+	PRIV_KEY=`cat keypair.pem` cargo test
 
 keypair.pem: scripts/keygen.sh
 	$<


### PR DESCRIPTION
This PR removes unused rules and adds `run` to make running the demo API locally easier.